### PR TITLE
URL of bbtools repair, linked in documentation, has changed

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -206,7 +206,7 @@ The option --nohits is equivalent to --tag --filter 0000 (zero for every genome 
 
 By adjusting the filters and, if necessary, undergoing several rounds of filtering it should be possible for a user to extract the desired reads.
 
-Filtering paired-end reads files separately will generate files with un-paired reads e.g. a read may be present in File1, but its corresponding pair may not be found in File2.  Also, the order of the reads in processed files may not correspond to on another.  Consequently, the resulting file pairs will need processing after filtering with FastQ Screen.  [Several tools are available (although not currently produced by us) to achieve this re-pairing.](https://jgi.doe.gov/data-and-tools/bbtools/bb-tools-user-guide/repair-guide)  
+Filtering paired-end reads files separately will generate files with un-paired reads e.g. a read may be present in File1, but its corresponding pair may not be found in File2.  Also, the order of the reads in processed files may not correspond to on another.  Consequently, the resulting file pairs will need processing after filtering with FastQ Screen.  [Several tools are available (although not currently produced by us) to achieve this re-pairing.](https://jgi.doe.gov/data-and-tools/software-tools/bbtools/bb-tools-user-guide/repair-guide/)  
 
 There may also may be occasions when, after filtering a FASTQ file, the tags need to be removed from the headers of each read.  This can be achieved using the script Misc/remove_tags.pl.
 


### PR DESCRIPTION
Hi,

I think the URL of the documentation for bbtools repair, which is linked in the documentation as a solution for pairing paired-end reads after filtering, has been changed.

